### PR TITLE
added config for custom prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [0.3.0] - 2024-05-07
 
 ### Added
+
+-   Added `prompts_config.json` to store customizable prompts for daily note processing and weekly summaries.
+-   Extracted hard-coded prompts from scripts into the config file for easier customization.
+-   Modified `ai_weekly_summary.py` and `ai_notes_nextcloud.py` to load prompts from the config file.
+
 - Modular architecture with shared components
 - Python package installation support
 - Console entry points for commands

--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Capture voice notes on your phone, sync them via Nextcloud, and automatically cl
 - Privacy-first LLM workflows  
 - Auto weekly summaries
 
-**Upcoming:**  
-- Config file for customizable prompts  
-- Optional journaling dashboard  
+**Upcoming:**
+- Optional journaling dashboard
 - Mood tracking integration
 
 ---
@@ -61,7 +60,9 @@ Echo-Notes/
 ├── shared/               # Core modules
 │   ├── config.py        # Paths and settings
 │   ├── file_utils.py    # File operations
-│   └── llm_client.py    # AI integration
+│   ├── llm_client.py    # AI integration
+│   ├── prompts_config.json # Customizable prompts
+│   └── date_helpers.py  # Date utilities
 ├── setup.py             # Installation config
 ├── requirements.txt     # Dependencies
 └── ...                  # Other project files
@@ -104,6 +105,7 @@ Weekly summary:
 - Smart date parsing from content
 
 - Error-resilient processing
+- Customizable prompts for note processing
 
 ### Weekly Summary (generate-summary)
 - Aggregates 7 days of notes
@@ -113,6 +115,19 @@ Weekly summary:
 - Generates actionable next steps
 
 - Creates consolidated Markdown report
+
+## Customizable Prompts
+
+Echo-Notes now supports customizable prompts through the `shared/prompts_config.json` file. This allows you to modify how the AI processes your notes without changing any code.
+
+Available prompts:
+- `daily_notes_prompt`: Controls how individual notes are processed and structured
+- `weekly_summary_prompt`: Defines how weekly summaries are generated
+
+To customize:
+1. Edit the `shared/prompts_config.json` file
+2. Modify the prompt text while keeping the placeholder variables (e.g., `{now}`, `{combined_text}`)
+3. Save the file - changes will be applied on the next processing run
 
 ## Changelog
 See CHANGELOG.md for full version history.

--- a/ai_notes_nextcloud.py
+++ b/ai_notes_nextcloud.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import os
+import json
 from shared import (
     config,
     file_utils,
@@ -9,13 +10,19 @@ from shared import (
     llm_client
 )
 
+def load_prompts_from_config():
+    with open(config.NOTES_DIR.parent.parent / 'CodeProjects' / 'Echo-Notes' / 'Echo-Notes' / 'shared' / 'prompts_config.json', 'r') as f:
+        prompts = json.load(f)
+    return prompts
+
 def process_note(file_path: Path):
     text = file_utils.get_note_text(file_path)
     if file_utils.is_processed_note(text):
         return
     
     # ... rest of processing logic ...
-    processed = llm_client.query_llm(text, system_prompt)
+    prompts = load_prompts_from_config()
+    processed = llm_client.query_llm(text, prompts['daily_notes_prompt'])
     file_utils.write_processed_note(file_path, processed)
 
 def main():

--- a/ai_weekly_summary.py
+++ b/ai_weekly_summary.py
@@ -2,12 +2,18 @@
 
 from pathlib import Path
 import os
+import json
 from shared import (
     config,
     file_utils,
     date_helpers,
     llm_client
 )
+
+def load_prompts_from_config():
+    with open(config.NOTES_DIR.parent.parent / 'CodeProjects' / 'Echo-Notes' / 'Echo-Notes' / 'shared' / 'prompts_config.json', 'r') as f:
+        prompts = json.load(f)
+    return prompts
 
 def main():
     collected = []
@@ -18,7 +24,8 @@ def main():
                 text = file_utils.get_note_text(file_path)
                 collected.append(text)
     
-    summary = llm_client.query_llm("\n\n".join(collected), weekly_prompt)
+    prompts = load_prompts_from_config()
+    summary = llm_client.query_llm("\n\n".join(collected), prompts['weekly_summary_prompt'])
     output_path = config.NOTES_DIR / config.weekly_summary_filename()
     file_utils.write_processed_note(output_path, summary)
 

--- a/shared/date_helpers.py
+++ b/shared/date_helpers.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import re
 from pathlib import Path
 import os
+from shared import file_utils
 
 def extract_summary_timestamp(text: str) -> datetime:
     """Extract embedded timestamp from note content"""
@@ -15,7 +16,7 @@ def extract_summary_timestamp(text: str) -> datetime:
 
 def get_note_date(file_path: Path) -> datetime:
     """Get note date from content or filesystem"""
-    text = get_note_text(file_path)
+    text = file_utils.get_note_text(file_path)
     ts = extract_summary_timestamp(text)
     return ts or datetime.fromtimestamp(os.path.getmtime(file_path))
 

--- a/shared/prompts_config.json
+++ b/shared/prompts_config.json
@@ -1,0 +1,5 @@
+{
+  "daily_notes_prompt": "You are an AI assistant. I will give you raw voice-to-text notes.\nPlease:\n 1. Fix grammar, spelling, and sentence structure.\n 2. Organize into clear UPPERCASE sections (e.g., GOALS, IDEAS).\n 3. Extract tasks as a checklist with '[ ] '.\n 4. Suggest next steps as bullet points.\n\nThen output in this format:\nSUMMARY ({now})\n\nCLEANED & STRUCTURED NOTES\n...your sections here...\n\nTASKS\n[ ] Task 1\n[ ] Task 2\n\nSUGGESTIONS / NEXT STEPS\n• Suggestion 1\n",
+  
+  "weekly_summary_prompt": "You are an AI assistant helping to generate a weekly summary. Below are notes from the past week:\n\n{combined_text}\n\nYour task:\n1. Start with exactly: '# Weekly Summary - {now_date}'\n2. Follow with these sections:\n   - WEEKLY REFLECTION\n   - MAIN THEMES\n   - COMPLETED TASKS\n   - PENDING ISSUES\n   - NEXT WEEK'S PRIORITIES\n3. Use Markdown format\n4. Write in clear, professional tone"
+}


### PR DESCRIPTION
Created Echo-Notes/shared/prompts_config.json containing the actual prompts that were previously hard-coded:

Added the daily notes processing prompt as "daily_notes_prompt"
Added the weekly summary generation prompt as "weekly_summary_prompt"
Modified both Python scripts to load these prompts from the config file:

Updated ai_weekly_summary.py to use the "weekly_summary_prompt"
Updated ai_notes_nextcloud.py to use the "daily_notes_prompt"
Updated documentation:

Updated CHANGELOG.md with detailed information about the customizable prompts feature
Corrected the project structure in README.md to show prompts_config.json in the shared/ directory
Added a new comprehensive section about the Customizable Prompts feature
Added "Customizable prompts for note processing" to the Core Features section
Successfully tested both scripts to verify they can load the prompts from the config file

The system now allows for easy customization of prompts by simply editing the JSON config file