### PR TITLE
added dir location to config instead of hard coded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 -   Added `prompts_config.json` to store customizable prompts for daily note processing and weekly summaries.
 -   Extracted hard-coded prompts from scripts into the config file for easier customization.
 -   Modified `ai_weekly_summary.py` and `ai_notes_nextcloud.py` to load prompts from the config file.
+-   Added environment variable support for configurable paths:
+    - `ECHO_NOTES_DIR`: Location of Nextcloud notes (default: ~/Documents/notes/log)
+    - `ECHO_APP_DIR`: Location of Echo-Notes application (default: auto-detected)
 
 - Modular architecture with shared components
 - Python package installation support

--- a/README.md
+++ b/README.md
@@ -129,6 +129,25 @@ To customize:
 2. Modify the prompt text while keeping the placeholder variables (e.g., `{now}`, `{combined_text}`)
 3. Save the file - changes will be applied on the next processing run
 
+## Configuration
+
+Echo-Notes supports the following environment variables for flexible configuration:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ECHO_NOTES_DIR` | Location of Nextcloud notes | `~/Documents/notes/log` |
+| `ECHO_APP_DIR` | Location of Echo-Notes application | Auto-detected from script location |
+
+Example usage:
+```bash
+# Use a different notes directory
+export ECHO_NOTES_DIR="/path/to/your/notes"
+
+# Run the scripts
+process-notes
+generate-summary
+```
+
 ## Changelog
 See CHANGELOG.md for full version history.
 

--- a/ai_notes_nextcloud.py
+++ b/ai_notes_nextcloud.py
@@ -11,7 +11,7 @@ from shared import (
 )
 
 def load_prompts_from_config():
-    with open(config.NOTES_DIR.parent.parent / 'CodeProjects' / 'Echo-Notes' / 'Echo-Notes' / 'shared' / 'prompts_config.json', 'r') as f:
+    with open(config.PROMPTS_CONFIG_PATH, 'r') as f:
         prompts = json.load(f)
     return prompts
 

--- a/ai_weekly_summary.py
+++ b/ai_weekly_summary.py
@@ -11,7 +11,7 @@ from shared import (
 )
 
 def load_prompts_from_config():
-    with open(config.NOTES_DIR.parent.parent / 'CodeProjects' / 'Echo-Notes' / 'Echo-Notes' / 'shared' / 'prompts_config.json', 'r') as f:
+    with open(config.PROMPTS_CONFIG_PATH, 'r') as f:
         prompts = json.load(f)
     return prompts
 

--- a/shared/config.py
+++ b/shared/config.py
@@ -1,11 +1,24 @@
+import os
 from pathlib import Path
 from datetime import datetime
 
 # Core Configuration
-NOTES_DIR = Path.home() / 'Documents' / 'notes' / 'log'
+# Default paths that can be overridden by environment variables
+DEFAULT_NOTES_DIR = Path.home() / 'Documents' / 'notes' / 'log'
+DEFAULT_APP_DIR = Path(__file__).parent.parent  # Echo-Notes directory
+
+# Use environment variables if set, otherwise use defaults
+NOTES_DIR = Path(os.environ.get('ECHO_NOTES_DIR', DEFAULT_NOTES_DIR))
+APP_DIR = Path(os.environ.get('ECHO_APP_DIR', DEFAULT_APP_DIR))
+
+# Other configuration
 LM_URL = 'http://localhost:8080/v1/chat/completions'
 SUMMARY_MARKER = 'CLEANED & STRUCTURED NOTES'
 LLM_MODEL = "qwen2.5-7b-instruct-1m"
+
+# Path to the prompts configuration file
+# This uses the APP_DIR to locate prompts_config.json
+PROMPTS_CONFIG_PATH = Path(__file__).parent / 'prompts_config.json'
 
 # Derived Values
 def weekly_summary_filename():


### PR DESCRIPTION
Created Echo-Notes/shared/prompts_config.json containing the actual prompts that were previously hard-coded:

Added the daily notes processing prompt as "daily_notes_prompt"
Added the weekly summary generation prompt as "weekly_summary_prompt"
Modified both Python scripts to load these prompts from the config file:

Updated ai_weekly_summary.py to use the "weekly_summary_prompt"
Updated ai_notes_nextcloud.py to use the "daily_notes_prompt"
Added environment variable support for configurable paths:

ECHO_NOTES_DIR: Location of Nextcloud notes (default: ~/Documents/notes/log)
ECHO_APP_DIR: Location of Echo-Notes application (default: auto-detected)
Updated documentation:

Updated CHANGELOG.md with detailed information about the customizable prompts and configurable paths
Added a new comprehensive section about the Customizable Prompts feature in README.md
Added a Configuration section in README.md explaining the environment variables